### PR TITLE
Add option for preventing the use of the gsm encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,30 @@ consortium.
 
 This encoding is the most widely used one when sending SMS messages.
 
-### Note on using ASCII instead of the GSM encoding
+### Note regarding non-ASCII symbols from the GSM encoding
 
-Sometimes you there are problems with the special non-ascii symbols which are in the GSM encoding like `æ ø å`.
-If you have such problems, you could configure the lib to treat messages that have such symbols as they are in Unicode.
+The GSM 03.38 encoding is used by default. This standard defines a set of
+symbols which can be encoded in 7-bits each, thus allowing up to 160 symbols
+per SMS message (each SMS message can contain up to 140 bytes of data).
 
-You will have to specify this in two ways:
+This standard covers most of the ASCII table, but also includes some non-ASCII
+symbols such as `æ`, `ø` and `å`. If you use these in your messages, you can
+still send them as GSM encoded, having a 160-symbol limit. This is technically
+correct.
+
+In reality, however, some SMS routes have problems delivering messages which
+contain such non-ASCII symbols in the GSM encoding. The special symbols might
+be omitted, or the message might not arrive at all.
+
+Thus, it might be safer to just send messages in Unicode if the message's text
+contains any non-ASCII symbols. This is not the default as it reduces the max
+symbols count to 70 per message, instead of 160, and you might not have any
+issues with GSM-encoded messages. In case you do, however, you can turn off
+support for the GSM encoding and just treat messages as Unicode if they contain
+non-ASCII symbols.
+
+In case you decide to do so, you have to specify it in both the Ruby and the
+JavaScript part of the library, like so:
 
 #### In Ruby
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ consortium.
 
 This encoding is the most widely used one when sending SMS messages.
 
+### Note on using ASCII instead of the GSM encoding
+
+Sometimes you there are problems with the special non-ascii symbols which are in the GSM encoding like `æ ø å`.
+If you have such problems, you could configure the lib to treat messages that have such symbols as they are in Unicode.
+
+You will have to specify this in two ways:
+
+#### In Ruby
+
+    SmsTools.use_gsm_encoding = false
+
+#### In Javascript
+
+    //= require sms_tools
+    SmsTools.use_gsm_encoding = false;
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/assets/javascripts/sms_tools/message.js.coffee
+++ b/lib/assets/javascripts/sms_tools/message.js.coffee
@@ -2,6 +2,9 @@ window.SmsTools ?= {}
 
 class SmsTools.Message
   maxLengthForEncoding:
+    ascii:
+      normal: 160
+      concatenated: 153
     gsm:
       normal: 160
       concatenated: 153
@@ -20,6 +23,7 @@ class SmsTools.Message
     '€':  true
     '\\': true
 
+  asciiPattern: /^[\x00-\x7F]*$/
   gsmEncodingPattern: /^[0-9a-zA-Z@Δ¡¿£_!Φ"¥Γ#èΛ¤éΩ%ùΠ&ìΨòΣçΘΞ:Ø;ÄäøÆ,<Ööæ=ÑñÅß>ÜüåÉ§à€~ \$\.\-\+\(\)\*\\\/\?\|\^\}\{\[\]\'\r\n]*$/
 
   constructor: (@text) ->
@@ -33,8 +37,19 @@ class SmsTools.Message
 
     concatenatedPartsCount * @maxLengthForEncoding[@encoding][messageType]
 
+  use_gsm_encoding: ->
+    if SmsTools['use_gsm_encoding'] == undefined
+      true
+    else
+      SmsTools['use_gsm_encoding']
+
   _encoding: ->
-    if @gsmEncodingPattern.test(@text) then 'gsm' else 'unicode'
+    if @asciiPattern.test(@text)
+      'ascii'
+    else if @use_gsm_encoding() and @gsmEncodingPattern.test(@text)
+      'gsm'
+    else
+      'unicode'
 
   _concatenatedPartsCount: ->
     encoding = @encoding

--- a/lib/sms_tools.rb
+++ b/lib/sms_tools.rb
@@ -5,3 +5,15 @@ require 'sms_tools/gsm_encoding'
 if defined?(::Rails) and ::Rails.version >= '3.1'
   require 'sms_tools/rails/engine'
 end
+
+module SmsTools
+  class << self
+    def use_gsm_encoding?
+      @use_gsm_encoding.nil? ? true : @use_gsm_encoding
+    end
+
+    def use_gsm_encoding=(value)
+      @use_gsm_encoding = value
+    end
+  end
+end

--- a/lib/sms_tools/encoding_detection.rb
+++ b/lib/sms_tools/encoding_detection.rb
@@ -3,6 +3,10 @@ require 'sms_tools/gsm_encoding'
 module SmsTools
   class EncodingDetection
     MAX_LENGTH_FOR_ENCODING = {
+      ascii: {
+        normal:       160,
+        concatenated: 153,
+      },
       gsm: {
         normal:       160,
         concatenated: 153,
@@ -20,7 +24,18 @@ module SmsTools
     end
 
     def encoding
-      @encoding ||= GsmEncoding.valid?(text) ? :gsm : :unicode
+      @encoding ||=
+        if text.ascii_only?
+          :ascii
+        elsif SmsTools.use_gsm_encoding? and GsmEncoding.valid?(text)
+          :gsm
+        else
+          :unicode
+        end
+    end
+
+    def ascii?
+      encoding == :ascii
     end
 
     def gsm?

--- a/lib/sms_tools/version.rb
+++ b/lib/sms_tools/version.rb
@@ -1,3 +1,3 @@
 module SmsTools
-  VERSION = '0.0.1'
+  VERSION = '0.1.0'
 end

--- a/spec/sms_tools/encoding_detection_spec.rb
+++ b/spec/sms_tools/encoding_detection_spec.rb
@@ -41,6 +41,14 @@ describe SmsTools::EncodingDetection do
       it "returns Unicode as encoding for special symbols defined in GSM 03.38" do
         detection_for('09azAZ@Δ¡¿£_!Φ"¥Γ#èΛ¤éΩ%ùΠ&ìΨòΣçΘΞ:Ø;ÄäøÆ,<Ööæ=ÑñÅß>ÜüåÉ§à€~').encoding.must_equal :unicode
       end
+
+      it 'returns ASCII for simple ASCII text' do
+        detection_for('Hello world.').encoding.must_equal :ascii
+      end
+
+      it "defaults to ASCII encoding for empty messages" do
+        detection_for('').encoding.must_equal :ascii
+      end
     end
   end
 

--- a/spec/sms_tools/encoding_detection_spec.rb
+++ b/spec/sms_tools/encoding_detection_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'sms_tools/encoding_detection'
+require 'sms_tools'
 
 describe SmsTools::EncodingDetection do
   it "exposes the original text as a method" do
@@ -7,26 +7,40 @@ describe SmsTools::EncodingDetection do
   end
 
   describe "encoding" do
-    it "defaults to GSM encoding for empty messages" do
-      detection_for('').encoding.must_equal :gsm
+    it "defaults to ASCII encoding for empty messages" do
+      detection_for('').encoding.must_equal :ascii
     end
 
-    it "returns GSM as encoding for simple ASCII text" do
-      detection_for('foo bar baz').encoding.must_equal :gsm
+    it "returns ASCII as encoding for simple ASCII text" do
+      detection_for('foo bar baz').encoding.must_equal :ascii
     end
 
     it "returns GSM as encoding for special symbols defined in GSM 03.38" do
       detection_for('09azAZ@Δ¡¿£_!Φ"¥Γ#èΛ¤éΩ%ùΠ&ìΨòΣçΘΞ:Ø;ÄäøÆ,<Ööæ=ÑñÅß>ÜüåÉ§à€~').encoding.must_equal :gsm
     end
 
-    it "returns GSM as encoding for puntucation and newline symbols" do
-      detection_for('Foo bar {} [baz]! Larodi $5. What else?').encoding.must_equal :gsm
-      detection_for("Spaces and newlines are GSM 03.38, too: \r\n").encoding.must_equal :gsm
+    it "returns ASCII as encoding for puntucation and newline symbols" do
+      detection_for('Foo bar {} [baz]! Larodi $5. What else?').encoding.must_equal :ascii
+      detection_for("Spaces and newlines are GSM 03.38, too: \r\n").encoding.must_equal :ascii
     end
 
     it "returns Unicode when non-GSM Unicode symbols are used" do
       detection_for('Foo bar лароди').encoding.must_equal :unicode
       detection_for('∞').encoding.must_equal :unicode
+    end
+
+    describe 'with SmsTools.use_gsm_encoding = false' do
+      before do
+        SmsTools.use_gsm_encoding = false
+      end
+
+      after do
+        SmsTools.use_gsm_encoding = true
+      end
+
+      it "returns Unicode as encoding for special symbols defined in GSM 03.38" do
+        detection_for('09azAZ@Δ¡¿£_!Φ"¥Γ#èΛ¤éΩ%ùΠ&ìΨòΣçΘΞ:Ø;ÄäøÆ,<Ööæ=ÑñÅß>ÜüåÉ§à€~').encoding.must_equal :unicode
+      end
     end
   end
 


### PR DESCRIPTION
If you are unlucky there is a chance some of symbols in your sms get removed.
This happens to chars which are by the GSM 03.38 standard but are
non-ascii (0-127). [I am having problems with the Clickatell
sms gateway. The symbols get removed from time to time depending on the
route taken by the message.]

The current change adds an option which allows you to ignore the use of
the gsm encoding and use only ascii and unicode. By default the gsm
encoding is in use.

To use the option you have to update set it in the ruby code and in
javascript.
