### PR TITLE
little encoding patch

### DIFF
--- a/lib/sms_tools/gsm_encoding.rb
+++ b/lib/sms_tools/gsm_encoding.rb
@@ -170,7 +170,7 @@ module SmsTools
         end
       end
 
-      gsm_encoded_string
+      gsm_encoded_string.force_encoding('US-ASCII')
     end
 
     def to_utf8(gsm_encoded_string)


### PR DESCRIPTION
I think the string returned here should be of 'us-ascii', not 'utf-8'.

Besides of being the original intendation of the class delivering a 7-bit compatible string, it will confuse (in my case) other tools like serialport, which feels invited to convert the string again and causes strange encoding errors at the modem level.

Besides that, you saved me lots of time releasing this, thanks!!! ;)
