### PR TITLE
Introducing use_ascii_encoding option

### DIFF
--- a/lib/assets/javascripts/sms_tools/message.js.coffee
+++ b/lib/assets/javascripts/sms_tools/message.js.coffee
@@ -43,8 +43,14 @@ class SmsTools.Message
     else
       SmsTools['use_gsm_encoding']
 
+   use_ascii_encoding: ->
+    if SmsTools['use_ascii_encoding'] == undefined
+      true
+    else
+      SmsTools['use_ascii_encoding']
+
   _encoding: ->
-    if @asciiPattern.test(@text)
+    if @asciiPattern.test(@text) and @use_ascii_encoding()
       'ascii'
     else if @use_gsm_encoding() and @gsmEncodingPattern.test(@text)
       'gsm'

--- a/lib/sms_tools.rb
+++ b/lib/sms_tools.rb
@@ -15,5 +15,13 @@ module SmsTools
     def use_gsm_encoding=(value)
       @use_gsm_encoding = value
     end
+
+    def use_ascii_encoding?
+      @use_ascii_encoding.nil? ? true : @use_ascii_encoding
+    end
+
+    def use_ascii_encoding=(value)
+      @use_ascii_encoding = value
+    end
   end
 end

--- a/lib/sms_tools/encoding_detection.rb
+++ b/lib/sms_tools/encoding_detection.rb
@@ -25,7 +25,7 @@ module SmsTools
 
     def encoding
       @encoding ||=
-        if text.ascii_only?
+        if text.ascii_only? and SmsTools.use_ascii_encoding?
           :ascii
         elsif SmsTools.use_gsm_encoding? and GsmEncoding.valid?(text)
           :gsm

--- a/spec/sms_tools/encoding_detection_spec.rb
+++ b/spec/sms_tools/encoding_detection_spec.rb
@@ -56,6 +56,28 @@ describe SmsTools::EncodingDetection do
         detection_for('').encoding.must_equal :ascii
       end
     end
+
+    describe 'with SmsTools.use_ascii_encoding = false' do
+      before do
+        SmsTools.use_ascii_encoding = false
+      end
+
+      after do
+        SmsTools.use_ascii_encoding = true
+      end
+
+      it "returns GSM 03.38 as encoding for special symbols defined in GSM 03.38" do
+        detection_for('09azAZ@Δ¡¿£_!Φ"¥Γ#èΛ¤éΩ%ùΠ&ìΨòΣCΘΞ:Ø;ÄäøÆ,<Ööæ=ÑñÅß>ÜüåÉ§à€~').encoding.must_equal :gsm
+      end
+
+      it 'returns GSM 03.38 for simple ASCII text' do
+        detection_for('Hello world.').encoding.must_equal :gsm
+      end
+
+      it "defaults to GSM 03.38 encoding for empty messages" do
+        detection_for('').encoding.must_equal :gsm
+      end
+    end
   end
 
   describe "message length" do
@@ -94,6 +116,26 @@ describe SmsTools::EncodingDetection do
     it "doesn't count double-space chars for Unicode encoding" do
       detection_for('Уникод: ^{}[~]|€\\').length.must_equal 17
       detection_for('Уникод: Σ: €').length.must_equal 12
+    end
+
+    describe 'with SmsTools.use_gsm_encoding = false' do
+      before do
+        SmsTools.use_gsm_encoding = false
+      end
+
+      it "returns ASCII encoded length for some specific symbols which are also in GSM 03.38" do
+        detection_for('[]').length.must_equal 2
+      end
+    end
+
+    describe 'with SmsTools.use_ascii_encoding = false' do
+      before do
+        SmsTools.use_ascii_encoding = false
+      end
+
+      it "returns GSM 03.38 encoded length for some specific symbols which are also in ASCII" do
+        detection_for('[]').length.must_equal 4
+      end
     end
   end
 


### PR DESCRIPTION
As for the opening issue [here](https://github.com/livebg/smstools/issues/6). It is good to introduce a new option for `use_ascii_encoding`. It could resolve the issue when you set `SmsTools.use_ascii_encoding = false`