### PR TITLE
Count emojis in unicode text

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in smstools.gemspec
 gemspec
+
+gem "unicode-emoji"

--- a/lib/sms_tools/encoding_detection.rb
+++ b/lib/sms_tools/encoding_detection.rb
@@ -1,4 +1,5 @@
 require 'sms_tools/gsm_encoding'
+require "unicode/emoji"
 
 module SmsTools
   class EncodingDetection
@@ -70,6 +71,7 @@ module SmsTools
     def length
       length = text.length
       length += text.chars.count { |char| GsmEncoding.double_byte?(char) } if gsm?
+      length += text.scan(Unicode::Emoji::REGEX).count if unicode?
 
       length
     end

--- a/spec/sms_tools/encoding_detection_spec.rb
+++ b/spec/sms_tools/encoding_detection_spec.rb
@@ -172,6 +172,9 @@ describe SmsTools::EncodingDetection do
       detection_for('Σ' * 160).concatenated_parts.must_equal 1
       detection_for('Σ' * 159 + '~').concatenated_parts.must_equal 2
       detection_for('Я' * 133 + '~').concatenated_parts.must_equal 2
+      detection_for('😊' * 36).concatenated_parts.must_equal 2
+      detection_for('a' * 68 + '😊').concatenated_parts.must_equal 1
+      detection_for('a' * 69 + '😊').concatenated_parts.must_equal 2
     end
   end
 


### PR DESCRIPTION
A normal unicode sms text consists of 140 Bytes so -> 70 * 2 byte characters but Emojis are 4 byte characters therefore count as 2 characters.

I extended the code in a similar fashion as it has been done for the GSM-7 double byte characters I also added a dependency ```unicode-emoji``` which offers Emoji regex directly, I thought that's the most fitting solution.

Tests are all green.