### PR TITLE
Count Complex Unicode Correctly

### DIFF
--- a/lib/sms_tools.rb
+++ b/lib/sms_tools.rb
@@ -1,6 +1,7 @@
 require 'sms_tools/version'
 require 'sms_tools/encoding_detection'
 require 'sms_tools/gsm_encoding'
+require 'sms_tools/unicode_encoding'
 
 if defined?(::Rails) and ::Rails.version >= '3.1'
   require 'sms_tools/rails/engine'

--- a/lib/sms_tools/encoding_detection.rb
+++ b/lib/sms_tools/encoding_detection.rb
@@ -68,9 +68,12 @@ module SmsTools
     # message, taking into account any double-space symbols in the GSM 03.38
     # encoding.
     def length
-      length = text.length
-      length += text.chars.count { |char| GsmEncoding.double_byte?(char) } if gsm?
-
+      if unicode?
+        length = text.chars.sum { |char| UnicodeEncoding.character_count(char) }
+      else
+        length = text.length
+        length += text.chars.count { |char| GsmEncoding.double_byte?(char) } if gsm?
+      end
       length
     end
   end

--- a/lib/sms_tools/unicode_encoding.rb
+++ b/lib/sms_tools/unicode_encoding.rb
@@ -1,0 +1,15 @@
+module SmsTools
+  module UnicodeEncoding
+    extend self
+
+    BASIC_PLANE = 0x0000..0xFFFF
+
+    # UCS-2/UTF-16 is used for unicode text messaging. UCS-2/UTF-16 represents characters in minimum
+    # 2-bytes, any characters in the basic plane are represented with 2-bytes, so each codepoint
+    # within the Basic Plane counts as a single character. Any codepoint outside the Basic Plane is
+    # encoded using 4-bytes and therefore counts as 2 characters in a text message.
+    def character_count(char)
+      char.each_codepoint.sum { |codepoint| BASIC_PLANE.include?(codepoint) ? 1 : 2 }
+    end
+  end
+end

--- a/spec/sms_tools/encoding_detection_spec.rb
+++ b/spec/sms_tools/encoding_detection_spec.rb
@@ -118,6 +118,14 @@ describe SmsTools::EncodingDetection do
       detection_for('Уникод: Σ: €').length.must_equal 12
     end
 
+    it "counts ZWJ unicode characters correctly" do
+      detection_for('😴').length.must_equal 2
+      detection_for('🛌🏽').length.must_equal 4
+      detection_for('🤾🏽‍♀️').length.must_equal 7
+      detection_for('🇵🇵').length.must_equal 4
+      detection_for('👩‍❤️‍👩').length.must_equal 8
+    end
+
     describe 'with SmsTools.use_gsm_encoding = false' do
       before do
         SmsTools.use_gsm_encoding = false
@@ -166,11 +174,16 @@ describe SmsTools::EncodingDetection do
       concatenated_parts_for length: 135, encoding: :unicode, must_be: 3
     end
 
-    it "counts parts for actual GSM-encoded and Unicode messages" do
+    it "counts parts for actual GSM-encoded messages" do
       detection_for('').concatenated_parts.must_equal 1
-      detection_for('Я').concatenated_parts.must_equal 1
       detection_for('Σ' * 160).concatenated_parts.must_equal 1
       detection_for('Σ' * 159 + '~').concatenated_parts.must_equal 2
+    end
+
+    it "counts parts for actual Unicode-encoded messages" do
+      detection_for('Я').concatenated_parts.must_equal 1
+      detection_for('Я' * 70).concatenated_parts.must_equal 1
+      detection_for('Я' * 71).concatenated_parts.must_equal 2
       detection_for('Я' * 133 + '~').concatenated_parts.must_equal 2
     end
   end


### PR DESCRIPTION
Some unicode characters, like emoji, are shown as a single character, but can be encoded as many, depending on the emoji, zero-width-joiners, tones, etc. This decodes the character into codepoints and determines how many encoded characters are required to send the emoji in a message.