### PR TITLE
Adding force encode from utf8

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The main API this class provides is the following:
 SmsTools::GsmEncoding.valid? message_text_in_utf8   # => true or false
 
 SmsTools::GsmEncoding.from_utf8 utf8_encoded_string # => a GSM 03.38 encoded string
+SmsTools::GsmEncoding.force_from_utf8 utf8_encoded_string # => if the message text has unsupported characters force a GSM 03.38 encoded string removing the unsupported characters
 SmsTools::GsmEncoding.to_utf8 gsm_encoded_string    # => an UTF-8 encoded string
 ```
 

--- a/lib/sms_tools/gsm_encoding.rb
+++ b/lib/sms_tools/gsm_encoding.rb
@@ -175,6 +175,16 @@ module SmsTools
       gsm_encoded_string
     end
 
+    def force_from_utf8(utf8_encoded_string)
+      gsm_encoded_string = ''
+
+      utf8_encoded_string.unpack('U*').each do |char|
+          gsm_encoded_string << converted  if converted = UTF8_TO_GSM[char]
+      end
+
+      gsm_encoded_string
+    end
+
     def to_utf8(gsm_encoded_string)
       utf8_encoded_string = ''
       escape              = false

--- a/spec/sms_tools/gsm_encoding_spec.rb
+++ b/spec/sms_tools/gsm_encoding_spec.rb
@@ -16,6 +16,20 @@ describe SmsTools::GsmEncoding do
     end
   end
 
+  describe 'force_from_utf8' do
+    it 'converts simple UTF-8 text to GSM 03.38' do
+      SmsTools::GsmEncoding.from_utf8('simple').must_equal 'simple'
+    end
+
+    it 'converts UTF-8 text with double-byte chars to GSM 03.38' do
+      SmsTools::GsmEncoding.from_utf8('foo []').must_equal "foo \e<\e>"
+    end
+
+    it 'converts UTF-8 text removing invalid characters' do
+      SmsTools::GsmEncoding.from_utf8('бsimple\t\v\b\a').must_equal "simple"
+    end
+  end
+
   describe 'to_utf8' do
     it 'converts simple GSM 03.38 to UTF-8' do
       SmsTools::GsmEncoding.to_utf8('simple').must_equal 'simple'


### PR DESCRIPTION
Sometimes clients use weird characters to send messages since they copy and paste text from the internet that contains characters that are not supported in GSM-7, in these cases it may be convenient to eliminate these characters so that the message is sent, hence the need to create a function that forces the conversion and returns a valid string.